### PR TITLE
Main tank static rotation

### DIFF
--- a/src/Shell.py
+++ b/src/Shell.py
@@ -34,8 +34,8 @@ class Shell(MovingObject):
         self.rect = self.image.get_rect(center=self.pos)
 
     def move(self, keys, dt):
-        self.pos.x += 5 * math.sin(math.radians(self.angle))
-        self.pos.y += 5 * math.cos(math.radians(self.angle))
+        self.pos.x += 15 * math.sin(math.radians(self.angle))
+        self.pos.y += 15 * math.cos(math.radians(self.angle))
 
     def check_collisions(self, game_objects):
         if game_utils.is_outside_the_window(self.pos.x, self.pos.y):

--- a/src/Tank.py
+++ b/src/Tank.py
@@ -1,6 +1,5 @@
 from random import randint
 import pygame
-import random
 import operator
 from src.MovingObject import MovingObject
 from src.Barrel import Barrel
@@ -29,13 +28,12 @@ class Tank(MovingObject):
 			pygame.K_a: ("left", Vector2(-1, 0)),
 			pygame.K_d: ("right", Vector2(1, 0))
 		}
+		self.op = None
 
 	def update(self):
-		print(f"I am {self.is_enemy}, my state is {self.state}")
 		if self.state == TankState.ROTATING:
-			self.angle = (self.angle + 3) % 360
-			self.image = pygame.transform.rotate(self.image_origin, self.angle)
-			print(f"My angle is {self.angle}")
+			self.angle = self.op(self.angle, 3) % 360
+			self.image = pygame.transform.rotate(self.image_origin, self.angle - 270)
 			if self.angle == self.target_angle:
 				self.state = TankState.IDLE
 				self.target_angle = None
@@ -82,29 +80,49 @@ class Tank(MovingObject):
 		if self.orientation != current_key_direction:
 			self.state = TankState.ROTATING
 			angle_map = {
-				"up": 180,
-				"down": -180,
-				"left": 90,
-				"right": 90,
+				"up": {
+					"left": 90, 
+					"right": -90,
+					"down": -180, 
+					},
+				"down": {
+					"up": 180,
+					"left": -90,
+					"right": 90
+				},
+				"left": {
+					"up": -90,
+					"down": 90,
+					"right": -180
+				},
+				"right": {
+					"up": 90,
+					"down": -90,
+					"left": 180
+				}
 			}
-			self.target_angle = (self.angle + angle_map[current_key_direction]) % 360
+			self.target_angle = (self.angle + angle_map[self.orientation][current_key_direction]) % 360
+			print(f"Target angle: {self.target_angle}\nCurrent angle {self.angle}")
+			self.op = operator.sub if self.target_angle < self.angle else operator.add
 			self.set_orientation(current_key_direction)
 
 	# move the pos coordinates of the object
 	def move(self, keys, dt):
 		if self.is_enemy:
 			return
-		for key, (direction, vec) in self.direction_map.items():
-			if keys[key]:
-				self.is_change_direction(direction)
-				if self.vel < TankMovement.MAX_VEL.value:
-					self.vel += TankMovement.ACCELERATION.value * dt
-					self.vel = min(self.vel, TankMovement.MAX_VEL.value)
-				displacement = vec * self.vel * dt
-				new_pos = self.pos + displacement
-				if not game_utils.is_outside_the_window(new_pos.x, new_pos.y):
-					self.pos = new_pos
-				break
+		
+		elif self.state != TankState.ROTATING:
+			for key, (direction, vec) in self.direction_map.items():
+				if keys[key]:
+					self.is_change_direction(direction)
+					if self.vel < TankMovement.MAX_VEL.value:
+						self.vel += TankMovement.ACCELERATION.value * dt
+						self.vel = min(self.vel, TankMovement.MAX_VEL.value)
+					displacement = vec * self.vel * dt
+					new_pos = self.pos + displacement
+					if not game_utils.is_outside_the_window(new_pos.x, new_pos.y):
+						self.pos = new_pos
+					break
 
 	def get_if_enemy(self):
 		return self.is_enemy

--- a/src/Tank.py
+++ b/src/Tank.py
@@ -13,7 +13,9 @@ class Tank(MovingObject):
 		super().__init__(tank_pos, tank_image, )
 		self.is_enemy=is_enemy
 		self.orientation = "up"
-		self.angle = TankMovement.START_ANGLE.value
+		self.angle = 0
+		# self.angle = randint(0, 360)
+		self.image = pygame.transform.rotate(self.image_origin, self.angle)
 		self.vel = TankMovement.INITIAL_VEL.value
 		self.barrel = Barrel(tank_base=self, barrel_pos=Vector2(tank_pos.x + 1, tank_pos.y + 23),
 							 barrel_image=barrel_image, starting_angle = randint(0, 360), player_tank=player_tank)
@@ -28,12 +30,11 @@ class Tank(MovingObject):
 			pygame.K_a: ("left", Vector2(-1, 0)),
 			pygame.K_d: ("right", Vector2(1, 0))
 		}
-		self.op = None
 
 	def update(self):
 		if self.state == TankState.ROTATING:
-			self.angle = self.op(self.angle, 3) % 360
-			self.image = pygame.transform.rotate(self.image_origin, self.angle - 270)
+			self.angle = (self.angle + 3 * (1 if self.diff > 0 else -1 )) % 360
+			self.image = pygame.transform.rotate(self.image_origin, self.angle)
 			if self.angle == self.target_angle:
 				self.state = TankState.IDLE
 				self.target_angle = None
@@ -102,8 +103,9 @@ class Tank(MovingObject):
 				}
 			}
 			self.target_angle = (self.angle + angle_map[self.orientation][current_key_direction]) % 360
-			print(f"Target angle: {self.target_angle}\nCurrent angle {self.angle}")
-			self.op = operator.sub if self.target_angle < self.angle else operator.add
+			self.diff = (self.target_angle - self.angle) % 360
+			if self.diff > 180:
+				self.diff -= 360
 			self.set_orientation(current_key_direction)
 
 	# move the pos coordinates of the object

--- a/src/utils/consts.py
+++ b/src/utils/consts.py
@@ -9,12 +9,12 @@ class TankMovement(Enum):
     MAX_VEL = 150
     ACCELERATION = 5
     DECELERATION = 0.05
-    START_ANGLE = 0
+    START_ANGLE = 270
 
 
 class FireRanges(Enum):
     TANK_DETECTION_RANGE = 300
-    SHELL_FIRE_RANGE = 270
+    SHELL_FIRE_RANGE = 900
 
 class ObjectTypes(Enum):
     TANK = "TANK"


### PR DESCRIPTION
Here's what this commit does:

  1. Gradual tank rotation (direction-aware)                                                                                                  
   
  The old code always rotated by +3 degrees regardless of direction. The new code:                                                            
  - Replaces the flat angle_map (one value per direction) with a nested map keyed by (current_orientation → target_direction), giving the   
  correct signed rotation delta (e.g. turning right from "up" is -90°, not +90°).                                                           
  - Stores self.op — either operator.add or operator.sub — so the tank rotates in the correct direction (clockwise vs counter-clockwise) each
  frame by 3°.                                                                                                                                
  - Fixes the pygame.transform.rotate call to subtract 270° offset, aligning the sprite with the coordinate system.                           

  2. No movement while rotating

  The move() method is now wrapped in elif self.state != TankState.ROTATING, so the tank is locked in place until it finishes rotating before
  it can move again.

  3. Shell speed increase

  Shell movement speed was bumped from 5 → 15 per frame.

  4. Start angle changed

  START_ANGLE changed from 0 → 270, aligning the tank's default facing direction with the sprite's visual orientation.

  5. Shell fire range increased

  SHELL_FIRE_RANGE changed from 270 → 900 — enemy tanks can now fire at much longer range.

  6. Minor cleanup

  - Removed an unused import random.
  - Removed debug print statements.
  - Added self.op = None initialization in __init__.